### PR TITLE
fix: correct zylos-core GitHub URLs (#12)

### DIFF
--- a/content/zylos-core/_index.md
+++ b/content/zylos-core/_index.md
@@ -12,7 +12,7 @@ layout: "product"
     Open-source framework for building autonomous AI agents. Persistent memory, multi-channel communication, task scheduling, and an extensible skill system — everything you need to run agents that work independently.
   </p>
   <div class="hero-actions">
-    <a href="https://github.com/coco-xyz/zylos" target="_blank" class="btn-primary">View on GitHub &rarr;</a>
+    <a href="https://github.com/zylos-ai/zylos-core" target="_blank" class="btn-primary">View on GitHub &rarr;</a>
   </div>
 </div>
 
@@ -46,8 +46,8 @@ layout: "product"
   <h2>Quick Start</h2>
 
 ```bash
-git clone https://github.com/coco-xyz/zylos.git
-cd zylos
+git clone https://github.com/zylos-ai/zylos-core.git
+cd zylos-core
 cp .env.example .env
 # Configure your environment
 ```
@@ -55,6 +55,6 @@ cp .env.example .env
 </div>
 
 <div class="bottom-links">
-  <a href="https://github.com/coco-xyz/zylos" target="_blank">GitHub &nearr;</a>
+  <a href="https://github.com/zylos-ai/zylos-core" target="_blank">GitHub &nearr;</a>
   <a href="https://github.com/coco-xyz" target="_blank">COCO Org &nearr;</a>
 </div>

--- a/content/zylos-core/_index.zh-cn.md
+++ b/content/zylos-core/_index.zh-cn.md
@@ -12,7 +12,7 @@ layout: "product"
     开源自主 AI Agent 框架。持久记忆、多通道通信、任务调度和可扩展技能系统——构建独立运行的 Agent 所需的一切。
   </p>
   <div class="hero-actions">
-    <a href="https://github.com/coco-xyz/zylos" target="_blank" class="btn-primary">在 GitHub 查看 &rarr;</a>
+    <a href="https://github.com/zylos-ai/zylos-core" target="_blank" class="btn-primary">在 GitHub 查看 &rarr;</a>
   </div>
 </div>
 
@@ -46,8 +46,8 @@ layout: "product"
   <h2>快速开始</h2>
 
 ```bash
-git clone https://github.com/coco-xyz/zylos.git
-cd zylos
+git clone https://github.com/zylos-ai/zylos-core.git
+cd zylos-core
 cp .env.example .env
 # 配置你的环境
 ```
@@ -55,6 +55,6 @@ cp .env.example .env
 </div>
 
 <div class="bottom-links">
-  <a href="https://github.com/coco-xyz/zylos" target="_blank">GitHub &nearr;</a>
+  <a href="https://github.com/zylos-ai/zylos-core" target="_blank">GitHub &nearr;</a>
   <a href="https://github.com/coco-xyz" target="_blank">COCO Org &nearr;</a>
 </div>


### PR DESCRIPTION
## Summary
- All GitHub links on the zylos-core page pointed to non-existent `coco-xyz/zylos`
- Fixed to `zylos-ai/zylos-core` (the actual repo) in both EN and ZH-CN files
- Also fixed `cd zylos` → `cd zylos-core` in Quick Start section

Closes #12

## Reviewer
@boot-coco