### PR TITLE
docs: update ClawMark product page for v0.6.2

### DIFF
--- a/content/clawmark/_index.md
+++ b/content/clawmark/_index.md
@@ -6,7 +6,7 @@ layout: "product"
 ---
 
 <div class="product-hero">
-  <span class="badge">Chrome Extension + Embeddable Widget</span>
+  <span class="badge">Chrome Extension + Embeddable Widget &middot; v0.6.2</span>
   <h1>ClawMark</h1>
   <p class="tagline">
     Annotate any webpage. Highlight text, add comments, and route feedback to GitHub Issues, Lark, Telegram, Slack, or email — all in one click.
@@ -33,12 +33,38 @@ layout: "product"
     <div class="feature-card">
       <div class="feature-icon">&#128640;</div>
       <h3>Flexible Routing</h3>
-      <p>Send annotations to GitHub, Lark, Telegram, Slack, email, or custom webhooks. Decentralized rule-based routing.</p>
+      <p>Send annotations to GitHub, Lark, Telegram, Slack, email, Linear, Jira, HxA Connect, or custom webhooks. Rule-based routing with priority control.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">&#128275;</div>
       <h3>Open Source</h3>
       <p>Self-host the server or use the official hosted service. Full control over your data and integrations.</p>
+    </div>
+  </div>
+</div>
+
+<div class="features-section">
+  <h2>What's New in v0.6</h2>
+  <div class="features-grid">
+    <div class="feature-card">
+      <div class="feature-icon">&#128200;</div>
+      <h3>Dashboard</h3>
+      <p>Full configuration center with 6 tabs — Overview, Account, Connection, Delivery Rules, Site Management, and About.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128274;</div>
+      <h3>Google Sign-In</h3>
+      <p>One-click Google OAuth authentication. Your identity syncs with annotations automatically.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128204;</div>
+      <h3>Annotation Overlay</h3>
+      <p>Draggable, resizable annotation window with delivery status display and custom tag support.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#127760;</div>
+      <h3>Site Management</h3>
+      <p>Blacklist or whitelist mode — control exactly which sites ClawMark is active on.</p>
     </div>
   </div>
 </div>
@@ -68,4 +94,5 @@ npm start
   <a href="https://github.com/coco-xyz/clawmark" target="_blank">GitHub &nearr;</a>
   <a href="https://github.com/coco-xyz/clawmark/releases" target="_blank">Releases &nearr;</a>
   <a href="https://github.com/coco-xyz/clawmark/issues" target="_blank">Issues &nearr;</a>
+  <a href="/clawmark/privacy/" target="_blank">Privacy Policy &nearr;</a>
 </div>

--- a/content/clawmark/_index.zh-cn.md
+++ b/content/clawmark/_index.zh-cn.md
@@ -6,7 +6,7 @@ layout: "product"
 ---
 
 <div class="product-hero">
-  <span class="badge">浏览器扩展 + 可嵌入 Widget</span>
+  <span class="badge">浏览器扩展 + 可嵌入 Widget &middot; v0.6.2</span>
   <h1>ClawMark</h1>
   <p class="tagline">
     标注任意网页。高亮文本、添加评论，一键将反馈发送到 GitHub Issues、Lark、Telegram、Slack 或邮件。
@@ -33,12 +33,38 @@ layout: "product"
     <div class="feature-card">
       <div class="feature-icon">&#128640;</div>
       <h3>灵活路由</h3>
-      <p>将标注发送到 GitHub、Lark、Telegram、Slack、邮件或自定义 Webhook。去中心化的规则路由。</p>
+      <p>将标注发送到 GitHub、Lark、Telegram、Slack、邮件、Linear、Jira、HxA Connect 或自定义 Webhook。支持优先级规则路由。</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">&#128275;</div>
       <h3>开源</h3>
       <p>可自托管服务端，也可使用官方托管服务。完全掌控你的数据和集成。</p>
+    </div>
+  </div>
+</div>
+
+<div class="features-section">
+  <h2>v0.6 新功能</h2>
+  <div class="features-grid">
+    <div class="feature-card">
+      <div class="feature-icon">&#128200;</div>
+      <h3>控制台</h3>
+      <p>完整的配置中心，6 个功能标签页——概览、账户、连接、分发规则、站点管理、关于。</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128274;</div>
+      <h3>Google 登录</h3>
+      <p>一键 Google OAuth 认证，标注自动关联你的身份信息。</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128204;</div>
+      <h3>标注悬浮窗</h3>
+      <p>可拖拽、可调整大小的标注窗口，支持分发状态显示和自定义标签。</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#127760;</div>
+      <h3>站点管理</h3>
+      <p>黑名单或白名单模式——精确控制 ClawMark 在哪些网站上启用。</p>
     </div>
   </div>
 </div>
@@ -68,4 +94,5 @@ npm start
   <a href="https://github.com/coco-xyz/clawmark" target="_blank">GitHub &nearr;</a>
   <a href="https://github.com/coco-xyz/clawmark/releases" target="_blank">Releases &nearr;</a>
   <a href="https://github.com/coco-xyz/clawmark/issues" target="_blank">Issues &nearr;</a>
+  <a href="/clawmark/privacy/" target="_blank">隐私政策 &nearr;</a>
 </div>


### PR DESCRIPTION
## Summary
- Add v0.6.2 version badge to product hero
- Add "What's New in v0.6" section: Dashboard, Google Sign-In, Annotation Overlay, Site Management
- Update routing targets list (added Linear, Jira, HxA Connect)
- Add Privacy Policy link to bottom links
- Both EN and CN pages updated

## Test plan
- [ ] Check labs.coco.xyz/clawmark/ renders correctly after merge
- [ ] Verify CN version at labs.coco.xyz/zh-cn/clawmark/

Generated with [Claude Code](https://claude.com/claude-code)