### PR TITLE
feat: dynamic What's New section from GitHub Releases (#8)

### DIFF
--- a/content/clawmark/_index.md
+++ b/content/clawmark/_index.md
@@ -135,6 +135,8 @@ npm start
           var sections = wnMatch[1].trim().split(/\n###\s+/).filter(Boolean);
           var html = '';
           // Icon map for common section names
+          // P1-1: XSS escape for content from GitHub API
+          function esc(s) { var d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
           var icons = {
             'dashboard': '&#128200;', 'welcome': '&#127881;', 'badge': '&#128178;',
             'ux': '&#127912;', 'polish': '&#10024;', 'annotation': '&#128204;',
@@ -154,7 +156,7 @@ npm start
             // Pick icon
             var iconKey = Object.keys(icons).find(function(k){ return title.toLowerCase().includes(k); }) || 'default';
             var icon = icons[iconKey];
-            html += '<div class="feature-card"><div class="feature-icon">' + icon + '</div><h3>' + shortTitle + '</h3><p>' + desc + '</p></div>';
+            html += '<div class="feature-card"><div class="feature-icon">' + icon + '</div><h3>' + esc(shortTitle) + '</h3><p>' + esc(desc) + '</p></div>';
           });
           if (html) wnContent.innerHTML = html;
         }

--- a/content/clawmark/_index.zh-cn.md
+++ b/content/clawmark/_index.zh-cn.md
@@ -68,7 +68,6 @@ layout: "product"
     </div>
   </div>
 </div>
-</div>
 
 <div class="quickstart-section">
   <h2>快速开始</h2>
@@ -135,12 +134,14 @@ npm start
         if (wnContent) {
           var sections = wnMatch[1].trim().split(/\n###\s+/).filter(Boolean);
           var html = '';
+          // P1-1: XSS escape for content from GitHub API
+          function esc(s) { var d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
           var icons = {
             'dashboard': '&#128200;', 'welcome': '&#127881;', 'badge': '&#128178;',
             'ux': '&#127912;', 'polish': '&#10024;', 'annotation': '&#128204;',
             'site': '&#127760;', 'sign': '&#128274;', 'auth': '&#128274;',
-            'error': '&#9889;', 'fix': '&#128295;', 'maintenance': '&#128296;',
-            'default': '&#11088;'
+            'error': '&#9889;', 'fix': '&#128295;', 'perf': '&#9889;',
+            'maintenance': '&#128296;', 'default': '&#11088;'
           };
           sections.forEach(function(sec) {
             var lines = sec.split('\n');
@@ -151,7 +152,7 @@ npm start
               .map(function(l){ return l.replace(/^\s*-\s*/, ''); });
             var desc = items.length ? items.join(' · ') : lines.slice(1).filter(Boolean)[0] || '';
             var iconKey = Object.keys(icons).find(function(k){ return title.toLowerCase().includes(k); }) || 'default';
-            html += '<div class="feature-card"><div class="feature-icon">' + icons[iconKey] + '</div><h3>' + shortTitle + '</h3><p>' + desc + '</p></div>';
+            html += '<div class="feature-card"><div class="feature-icon">' + icons[iconKey] + '</div><h3>' + esc(shortTitle) + '</h3><p>' + esc(desc) + '</p></div>';
           });
           if (html) wnContent.innerHTML = html;
         }


### PR DESCRIPTION
## Summary
ClawMark GitLab #8 — dynamically generate the "What's New" feature cards from GitHub Releases API.

- Parse `## What's New` section from latest release → generate feature cards
- Title auto-updates (e.g., "What's New in v0.6.3")
- XSS protection via `esc()` helper
- EN + ZH-CN pages updated
- Fallback to hardcoded cards if API fails

Author: Lisa (lisa-cocoai, GitHub flagged). Reviewed by Jessie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)