### PR TITLE
fix: add full production config to ClawMark Dashboard

### DIFF
--- a/static/clawmark/dashboard/index.html
+++ b/static/clawmark/dashboard/index.html
@@ -7,7 +7,11 @@
     <link rel="icon" href="/clawmark/dashboard/assets/favicon-DTR16ASe.svg" type="image/svg+xml">
     <script>
         const ClawMarkConfig = {
+            DEFAULT_SERVER: 'https://api.coco.xyz/clawmark',
+            DASHBOARD_URL: 'https://labs.coco.xyz/clawmark/dashboard',
+            GOOGLE_CLIENT_ID: '530440081185-32t15m4gqndq7qab6g57a25i6gfc1gmn.apps.googleusercontent.com',
             EXTENSION_ID: 'blgnfnelakbffkgainibpeejlfbimikn',
+            ENV: 'production',
         };
     </script>
   <script type="module" crossorigin src="/clawmark/dashboard/assets/index-CI43NNeX.js"></script>


### PR DESCRIPTION
## Summary
- Dashboard `ClawMarkConfig` block was missing `DEFAULT_SERVER`, `DASHBOARD_URL`, `GOOGLE_CLIENT_ID`, and `ENV`
- This caused OAuth login failure and no API server connection on labs.coco.xyz/clawmark/dashboard/
- Added full production config matching Kevin's confirmed values

## Config Added
```js
DEFAULT_SERVER: 'https://api.coco.xyz/clawmark',
DASHBOARD_URL: 'https://labs.coco.xyz/clawmark/dashboard',
GOOGLE_CLIENT_ID: '530440081185-32t15m4gqndq7qab6g57a25i6gfc1gmn.apps.googleusercontent.com',
ENV: 'production',
```

## Test plan
- [ ] Verify labs.coco.xyz/clawmark/dashboard/ loads with Google Sign-in working
- [ ] Verify dashboard connects to api.coco.xyz/clawmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)