### PR TITLE
fix: homepage nav, slogan, stats layout (#27 #28 #30)

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -51,6 +51,18 @@ params:
     links:
       - github: https://github.com/coco-xyz
 
+menus:
+  main:
+    - name: Zylos
+      pageRef: zylos-core
+      weight: 10
+    - name: HxA Connect
+      pageRef: hxa-connect
+      weight: 20
+    - name: ClawMark
+      pageRef: clawmark
+      weight: 30
+
 markup:
   goldmark:
     renderer:

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,6 +1,6 @@
 home:
-  hero_title_1: "Build with AI."
-  hero_title_2: "Ship Together."
+  hero_title_1: "Build AI Teams."
+  hero_title_2: "Deploy in Minutes."
   hero_lead: "Open-source tools and infrastructure for human-agent collaboration. From web annotation to team orchestration — everything you need to work alongside AI."
   hero_cta: "Explore on GitHub"
   hero_cta2: "Visit coco.xyz"

--- a/i18n/zh-cn.yaml
+++ b/i18n/zh-cn.yaml
@@ -1,6 +1,6 @@
 home:
-  hero_title_1: "与 AI 共建。"
-  hero_title_2: "协同交付。"
+  hero_title_1: "构建 AI 团队。"
+  hero_title_2: "分钟级部署。"
   hero_lead: "开源工具与基础设施，让人类与 AI Agent 高效协作。从网页标注到团队编排——你需要的一切，尽在这里。"
   hero_cta: "在 GitHub 探索"
   hero_cta2: "访问 coco.xyz"

--- a/layouts/partials/home/custom.html
+++ b/layouts/partials/home/custom.html
@@ -13,6 +13,19 @@
     </div>
   </div>
 
+  <!-- Stats Bar -->
+  <div class="stats-bar">
+    <div class="stat-item">
+      <span class="stat-number">10+</span>
+      <span class="stat-label">{{ i18n "stats.repos" }}</span>
+    </div>
+    <div class="stat-divider"></div>
+    <div class="stat-item">
+      <span class="stat-number">2,200+</span>
+      <span class="stat-label">{{ i18n "stats.github_stars" }}</span>
+    </div>
+  </div>
+
   <!-- Featured Projects -->
   <div class="featured-section">
     <div style="text-align:center;">
@@ -187,19 +200,6 @@
   </div>
   <div style="text-align:center; margin-top: 0.5rem; margin-bottom: 2rem;">
     <a href="https://github.com/coco-xyz" target="_blank" class="more-link">{{ i18n "common.more_claw" }} &rarr;</a>
-  </div>
-
-  <!-- Stats Bar -->
-  <div class="stats-bar">
-    <div class="stat-item">
-      <span class="stat-number">10+</span>
-      <span class="stat-label">{{ i18n "stats.repos" }}</span>
-    </div>
-    <div class="stat-divider"></div>
-    <div class="stat-item">
-      <span class="stat-number">2,200+</span>
-      <span class="stat-label">{{ i18n "stats.github_stars" }}</span>
-    </div>
   </div>
 
   <!-- Bottom Links -->


### PR DESCRIPTION
## Summary
- **#27**: Added Zylos, HxA Connect, ClawMark to the navigation bar via Hugo menus
- **#28**: Updated hero slogan from "Build with AI. Ship Together." to "Build AI Teams. Deploy in Minutes." (matches coco.xyz)
- **#30**: Moved stats bar (10+ repos / 2,200+ GitHub stars) from bottom to above featured projects

## Changes
- `hugo.yaml`: Added `menus.main` with 3 nav items
- `i18n/en.yaml` + `i18n/zh-cn.yaml`: Updated hero title strings
- `layouts/partials/home/custom.html`: Relocated stats bar HTML block

## Test plan
- [ ] Verify nav bar shows Zylos / HxA Connect / ClawMark links
- [ ] Verify hero text reads "Build AI Teams. Deploy in Minutes."
- [ ] Verify stats bar appears before featured projects section
- [ ] Check zh-cn locale renders correctly

Closes #27, closes #28, closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)