### PR TITLE
fix: featured projects spotlight design (#29)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -194,6 +194,22 @@ html {
   text-decoration: none;
 }
 
+.featured-card-spotlight {
+  border-color: rgb(var(--color-primary-500));
+  box-shadow: 0 4px 16px rgba(245, 158, 11, 0.12);
+  transform: scale(1.04);
+}
+
+.dark .featured-card-spotlight {
+  border-color: rgb(var(--color-primary-400));
+  box-shadow: 0 4px 16px rgba(245, 158, 11, 0.2);
+}
+
+.featured-card-spotlight:hover {
+  box-shadow: 0 8px 28px rgba(245, 158, 11, 0.25);
+  transform: scale(1.04) translateY(-2px);
+}
+
 .featured-card-header {
   display: flex;
   justify-content: space-between;

--- a/layouts/partials/home/custom.html
+++ b/layouts/partials/home/custom.html
@@ -48,7 +48,7 @@
         </div>
       </a>
 
-      <a href="{{ "hxa-connect/" | relURL }}" class="featured-card">
+      <a href="https://connect.coco.xyz/" target="_blank" class="featured-card featured-card-spotlight">
         <div class="featured-card-header">
           <span class="status-badge status-live">{{ i18n "status.live" }}</span>
           <span class="featured-star">&#9733;</span>
@@ -57,7 +57,7 @@
         <h3>{{ i18n "products.hxa_connect_name" }}</h3>
         <p class="featured-desc">{{ i18n "products.hxa_connect_featured_desc" }}</p>
         <div class="featured-card-links">
-          <span class="featured-link">{{ i18n "common.quick_start" }}</span>
+          <span class="featured-link">Explore &rarr;</span>
           <span class="featured-link-sep">&middot;</span>
           <span class="featured-link">GitHub</span>
         </div>
@@ -75,8 +75,6 @@
           <span class="featured-link">{{ i18n "common.try_it" }}</span>
           <span class="featured-link-sep">&middot;</span>
           <span class="featured-link">GitHub</span>
-          <span class="featured-link-sep">&middot;</span>
-          <span class="featured-link">Chrome Web Store</span>
         </div>
       </a>
 


### PR DESCRIPTION
## Summary
- HxA Connect card gets **spotlight styling** as the C-position featured project (slightly scaled up, highlighted border, stronger hover shadow)
- HxA Connect card links directly to **connect.coco.xyz** with "Explore →" CTA
- Removed "Chrome Web Store" link from ClawMark card (CWS upload is blocked)

## Changes
- `assets/css/custom.css`: Added `.featured-card-spotlight` styles (scale, border, shadow for light/dark)
- `layouts/partials/home/custom.html`: HxA Connect card → spotlight class + connect.coco.xyz link; ClawMark card → removed CWS link

## Test plan
- [ ] HxA Connect card visually stands out from the other two
- [ ] HxA Connect card links to connect.coco.xyz (not product page)
- [ ] ClawMark card no longer shows "Chrome Web Store"
- [ ] Dark mode renders correctly

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)