### PR TITLE
fix: center navigation bar items (#38)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -5,6 +5,15 @@ html {
   font-family: 'Plus Jakarta Sans', ui-sans-serif, system-ui, sans-serif;
 }
 
+/* ===== HEADER NAV ===== */
+.main-menu {
+  justify-content: center;
+}
+
+.main-menu > div:last-child {
+  margin-inline-start: 0 !important;
+}
+
 /* ===== HOMEPAGE HERO ===== */
 .coco-hero {
   padding: 5rem 1.5rem 3rem;


### PR DESCRIPTION
## Summary
- Navigation bar items (Zylos / HxA Connect / ClawMark) are now centered in the header
- Overrides Blowfish theme's default `ms-auto` which pushed items to the right

## Changes
- `assets/css/custom.css`: Added `.main-menu` centering + removed auto margin

## Test plan
- [ ] Nav items centered on desktop
- [ ] Nav items look correct on mobile (hamburger menu)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)