### PR TITLE
fix: center featured projects nav on homepage (GL#30)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -91,6 +91,60 @@ html {
   color: rgb(var(--color-neutral-200));
 }
 
+/* ===== PRODUCT NAV ===== */
+.product-nav {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  margin: -1rem auto 2rem;
+  padding: 0.75rem 1.5rem;
+}
+
+.product-nav-item {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgb(var(--color-neutral-600));
+  text-decoration: none;
+  padding: 0.4rem 1rem;
+  border-radius: 0.5rem;
+  transition: color 200ms ease, background 200ms ease;
+}
+
+.product-nav-item:hover {
+  color: rgb(var(--color-primary-600));
+  background: rgba(var(--color-primary-500), 0.08);
+  text-decoration: none;
+}
+
+.dark .product-nav-item {
+  color: rgb(var(--color-neutral-300));
+}
+
+.dark .product-nav-item:hover {
+  color: rgb(var(--color-primary-400));
+  background: rgba(var(--color-primary-500), 0.12);
+}
+
+.product-nav-sep {
+  color: rgb(var(--color-neutral-300));
+  font-size: 0.85rem;
+}
+
+.dark .product-nav-sep {
+  color: rgb(var(--color-neutral-600));
+}
+
+@media (max-width: 480px) {
+  .product-nav {
+    gap: 0.5rem;
+  }
+  .product-nav-item {
+    font-size: 0.85rem;
+    padding: 0.3rem 0.6rem;
+  }
+}
+
 /* ===== STATUS BADGES ===== */
 .status-badge {
   display: inline-block;

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -51,18 +51,6 @@ params:
     links:
       - github: https://github.com/coco-xyz
 
-menus:
-  main:
-    - name: Zylos
-      pageRef: zylos-core
-      weight: 10
-    - name: HxA Connect
-      pageRef: hxa-connect
-      weight: 20
-    - name: ClawMark
-      pageRef: clawmark
-      weight: 30
-
 markup:
   goldmark:
     renderer:

--- a/layouts/partials/home/custom.html
+++ b/layouts/partials/home/custom.html
@@ -13,6 +13,15 @@
     </div>
   </div>
 
+  <!-- Product Nav -->
+  <nav class="product-nav">
+    <a href="{{ "zylos-core/" | relURL }}" class="product-nav-item">&#129302; Zylos</a>
+    <span class="product-nav-sep">&middot;</span>
+    <a href="{{ "hxa-connect/" | relURL }}" class="product-nav-item">&#128225; HxA Connect</a>
+    <span class="product-nav-sep">&middot;</span>
+    <a href="{{ "clawmark/" | relURL }}" class="product-nav-item">&#9997;&#65039; ClawMark</a>
+  </nav>
+
   <!-- Stats Bar -->
   <div class="stats-bar">
     <div class="stat-item">


### PR DESCRIPTION
## Summary
- Replaces Hugo `menus.main` nav (right-aligned in header) with a custom centered product nav strip below the hero section
- Three featured projects displayed as centered pill links with emoji icons and dot separators
- Hover effect with brand color highlight

## Changes
- `hugo.yaml`: Removed `menus.main` config (nav items were right-aligned, looked off)
- `layouts/partials/home/custom.html`: Added `<nav class="product-nav">` between hero and stats bar
- `assets/css/custom.css`: Added `.product-nav` styles with responsive breakpoints

## Test plan
- [ ] Nav shows centered below hero: 🤖 Zylos · 📡 HxA Connect · ✍️ ClawMark
- [ ] Hover highlights with brand color pill
- [ ] Responsive on mobile (smaller text + padding)
- [ ] Dark mode renders correctly

Ref: git.coco.xyz/hxanet/clawmark/-/issues/30

🤖 Generated with [Claude Code](https://claude.com/claude-code)