### PR TITLE
feat: standard product nav on all pages (#41)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -126,6 +126,16 @@ html {
   background: rgba(var(--color-primary-500), 0.12);
 }
 
+.product-nav-active {
+  color: rgb(var(--color-primary-600)) !important;
+  background: rgba(var(--color-primary-500), 0.1);
+}
+
+.dark .product-nav-active {
+  color: rgb(var(--color-primary-400)) !important;
+  background: rgba(var(--color-primary-500), 0.15);
+}
+
 .product-nav-sep {
   color: rgb(var(--color-neutral-300));
   font-size: 0.85rem;

--- a/layouts/_default/product.html
+++ b/layouts/_default/product.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+  {{ partial "product-nav.html" . }}
   <article class="max-w-full">
     <section class="max-w-full prose dark:prose-invert">
       {{ .Content }}

--- a/layouts/partials/home/custom.html
+++ b/layouts/partials/home/custom.html
@@ -14,13 +14,7 @@
   </div>
 
   <!-- Product Nav -->
-  <nav class="product-nav">
-    <a href="{{ "zylos-core/" | relURL }}" class="product-nav-item">&#129302; Zylos</a>
-    <span class="product-nav-sep">&middot;</span>
-    <a href="{{ "hxa-connect/" | relURL }}" class="product-nav-item">&#128225; HxA Connect</a>
-    <span class="product-nav-sep">&middot;</span>
-    <a href="{{ "clawmark/" | relURL }}" class="product-nav-item">&#9997;&#65039; ClawMark</a>
-  </nav>
+  {{ partial "product-nav.html" . }}
 
   <!-- Stats Bar -->
   <div class="stats-bar">

--- a/layouts/partials/product-nav.html
+++ b/layouts/partials/product-nav.html
@@ -1,0 +1,15 @@
+{{/* Product navigation bar — shared between homepage and product pages */}}
+{{ $currentSection := "" }}
+{{ if .IsSection }}{{ $currentSection = .Section }}{{ end }}
+{{ if .IsPage }}{{ $currentSection = .Section }}{{ end }}
+<nav class="product-nav">
+  <a href="{{ "/" | relURL }}" class="product-nav-item{{ if .IsHome }} product-nav-active{{ end }}">&#127968; Home</a>
+  <span class="product-nav-sep">&middot;</span>
+  <a href="{{ "zylos-core/" | relURL }}" class="product-nav-item{{ if eq $currentSection "zylos-core" }} product-nav-active{{ end }}">&#129302; Zylos</a>
+  <span class="product-nav-sep">&middot;</span>
+  <a href="{{ "hxa-connect/" | relURL }}" class="product-nav-item{{ if eq $currentSection "hxa-connect" }} product-nav-active{{ end }}">&#128225; HxA Connect</a>
+  <span class="product-nav-sep">&middot;</span>
+  <a href="{{ "clawmark/" | relURL }}" class="product-nav-item{{ if eq $currentSection "clawmark" }} product-nav-active{{ end }}">&#9997;&#65039; ClawMark</a>
+  <span class="product-nav-sep">&middot;</span>
+  <a href="{{ "clawfeed/" | relURL }}" class="product-nav-item{{ if eq $currentSection "clawfeed" }} product-nav-active{{ end }}">&#128218; ClawFeed</a>
+</nav>


### PR DESCRIPTION
## Summary
- Extract product-nav into shared partial (`layouts/partials/product-nav.html`)
- Add product nav bar to `product.html` layout — all product pages now get the same navigation
- Homepage reuses the same partial (DRY)
- Active page highlighting (current product is visually marked)
- Products in nav: Home · Zylos · HxA Connect · ClawMark · ClawFeed

## Test
Preview: https://jessie.coco.site/labs/clawmark/

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)