### PR TITLE
fix: #30 center highlight titles on Labs page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -236,6 +236,7 @@ html {
 .featured-card-icon {
   font-size: 2.5rem;
   margin-bottom: 0.75rem;
+  text-align: center;
 }
 
 .featured-card h3 {
@@ -243,6 +244,7 @@ html {
   font-weight: 700;
   color: rgb(var(--color-neutral-900));
   margin: 0 0 0.5rem;
+  text-align: center;
 }
 
 .dark .featured-card h3 {
@@ -340,6 +342,7 @@ html {
 .product-card .card-icon {
   font-size: 2rem;
   margin-bottom: 0.75rem;
+  text-align: center;
 }
 
 .product-card h3 {
@@ -347,6 +350,7 @@ html {
   font-weight: 700;
   color: rgb(var(--color-neutral-900));
   margin: 0 0 0.5rem;
+  text-align: center;
 }
 
 .dark .product-card h3 {


### PR DESCRIPTION
Center text-align on featured card icons/titles and product card icons/titles. 4 lines added.

Vila's fix for ClawMark #30 — Kevin feedback: titles not centered, 'too ugly'.