### PR TITLE
chore: add OpenClaw ecosystem compatibility messaging

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -11,7 +11,7 @@ Building tools that empower humans and AI agents to work together seamlessly.
 
 | Product | Description | |
 |---------|-------------|---|
-| **[Zylos](zylos-core/)** | Autonomous AI agent framework | {{< button href="https://github.com/zylos-ai/zylos-core" target="_blank" >}}GitHub{{< /button >}} |
+| **[Zylos](zylos-core/)** | Autonomous AI agent framework. Compatible with the OpenClaw ecosystem. | {{< button href="https://github.com/zylos-ai/zylos-core" target="_blank" >}}GitHub{{< /button >}} |
 | **Zylos Telegram** | Telegram messaging component | {{< button href="https://github.com/zylos-ai/zylos-telegram" target="_blank" >}}GitHub{{< /button >}} |
 
 {{< button href="https://github.com/zylos-ai" target="_blank" >}}More Zylos Projects →{{< /button >}}

--- a/content/zylos-core/_index.md
+++ b/content/zylos-core/_index.md
@@ -42,6 +42,13 @@ layout: "product"
   </div>
 </div>
 
+<div class="features-section">
+  <h2>OpenClaw Compatibility</h2>
+  <p>
+    Zylos is fully compatible with the <strong>OpenClaw ecosystem</strong> — agents can install and use OpenClaw skills and plugins directly. All seven capability dimensions (memory, communication, scheduling, skills, browser, messaging, and image generation) are available out of the box.
+  </p>
+</div>
+
 <div class="quickstart-section">
   <h2>Quick Start</h2>
 

--- a/content/zylos-core/_index.zh-cn.md
+++ b/content/zylos-core/_index.zh-cn.md
@@ -42,6 +42,13 @@ layout: "product"
   </div>
 </div>
 
+<div class="features-section">
+  <h2>OpenClaw 兼容性</h2>
+  <p>
+    Zylos 全面兼容 <strong>OpenClaw 生态</strong>——Agent 可以直接安装和使用 OpenClaw 技能与插件。记忆、通信、调度、技能、浏览器、消息和图像生成七大能力维度均已完整支持。
+  </p>
+</div>
+
 <div class="quickstart-section">
   <h2>快速开始</h2>
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -42,8 +42,8 @@ products:
   hxa_workspace_desc: "Collaboration platform with identity management, shared knowledge, dashboards, and multi-agent meetings."
 
   zylos_core_name: "Zylos"
-  zylos_core_desc: "Autonomous AI agent framework. Persistent memory, multi-channel communication, task scheduling, and extensible skill system."
-  zylos_core_featured_desc: "Give your AI a life — open-source agent infrastructure for team collaboration. Persistent memory, multi-channel communication, task scheduling, and extensible skill system."
+  zylos_core_desc: "Autonomous AI agent framework. Persistent memory, multi-channel communication, task scheduling, and extensible skill system. Compatible with the OpenClaw ecosystem."
+  zylos_core_featured_desc: "Give your AI a life — open-source agent infrastructure for team collaboration. Persistent memory, multi-channel communication, task scheduling, and extensible skill system. Compatible with the OpenClaw ecosystem."
   zylos_telegram_name: "Zylos Telegram"
   zylos_telegram_desc: "Telegram messaging component. DM, groups, media sharing, and access control."
   zylos_lark_name: "Zylos Lark"

--- a/i18n/zh-cn.yaml
+++ b/i18n/zh-cn.yaml
@@ -42,8 +42,8 @@ products:
   hxa_workspace_desc: "协作平台——身份管理、共享知识库、仪表盘和多 Agent 会议。"
 
   zylos_core_name: "Zylos"
-  zylos_core_desc: "自主 AI Agent 框架。持久记忆、多通道通信、任务调度和可扩展技能系统。"
-  zylos_core_featured_desc: "赋予 AI 生命 — 开源 Agent 协作基础设施。持久记忆、多通道通信、任务调度和可扩展技能系统。"
+  zylos_core_desc: "自主 AI Agent 框架。持久记忆、多通道通信、任务调度和可扩展技能系统。全面兼容 OpenClaw 生态。"
+  zylos_core_featured_desc: "赋予 AI 生命 — 开源 Agent 协作基础设施。持久记忆、多通道通信、任务调度和可扩展技能系统。全面兼容 OpenClaw 生态。"
   zylos_telegram_name: "Zylos Telegram"
   zylos_telegram_desc: "Telegram 消息组件。私聊、群组、媒体分享和访问控制。"
   zylos_lark_name: "Zylos Lark"

--- a/layouts/partials/home/custom.html
+++ b/layouts/partials/home/custom.html
@@ -99,6 +99,7 @@
         <span class="card-tag">#agent</span>
         <span class="card-tag">#framework</span>
         <span class="card-tag">#autonomous</span>
+        <span class="card-tag">#OpenClaw</span>
       </div>
     </a>
 

--- a/static/.well-known/ai-plugin.json
+++ b/static/.well-known/ai-plugin.json
@@ -3,7 +3,7 @@
   "name_for_human": "COCO Labs",
   "name_for_model": "coco_labs",
   "description_for_human": "Open-source tools and infrastructure for human-agent collaboration.",
-  "description_for_model": "COCO Labs is a product showcase for open-source AI agent tools. Products include: Zylos (autonomous agent framework with persistent memory, multi-channel communication, task scheduling), ClawMark (web annotation Chrome extension), ClawFeed (AI RSS reader), HxA Connect (agent-to-agent messaging protocol), and HxA Teams (team organization templates). All products are free and open-source on GitHub (github.com/coco-xyz and github.com/zylos-ai).",
+  "description_for_model": "COCO Labs is a product showcase for open-source AI agent tools. Products include: Zylos (autonomous agent framework with persistent memory, multi-channel communication, task scheduling — fully compatible with the OpenClaw ecosystem), ClawMark (web annotation Chrome extension), ClawFeed (AI RSS reader), HxA Connect (agent-to-agent messaging protocol), and HxA Teams (team organization templates). All products are free and open-source on GitHub (github.com/coco-xyz and github.com/zylos-ai).",
   "auth": {
     "type": "none"
   },

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -7,7 +7,7 @@ COCO Labs is the product showcase for COCO (coco.xyz), an organization building 
 ## Products
 
 ### Zylos Series — Open Source Agent Framework
-- [Zylos Core](https://labs.coco.xyz/zylos-core/): Autonomous AI agent framework with persistent memory, multi-channel communication, task scheduling, and extensible skill system. GitHub: https://github.com/zylos-ai/zylos-core
+- [Zylos Core](https://labs.coco.xyz/zylos-core/): Autonomous AI agent framework with persistent memory, multi-channel communication, task scheduling, and extensible skill system. Compatible with the OpenClaw ecosystem. GitHub: https://github.com/zylos-ai/zylos-core
 - Zylos Telegram: Telegram messaging component. GitHub: https://github.com/zylos-ai/zylos-telegram
 - Zylos Lark: Lark & Feishu messaging component. GitHub: https://github.com/zylos-ai/zylos-lark
 - Zylos Browser: Browser automation component. GitHub: https://github.com/zylos-ai/zylos-browser


### PR DESCRIPTION
## Summary
- Add "Compatible with the OpenClaw ecosystem" / "全面兼容 OpenClaw 生态" to all user-facing Zylos descriptions (i18n, product cards, listing page)
- Add dedicated OpenClaw Compatibility section to the Zylos product page (EN + ZH-CN) with capability dimension details
- Add `#OpenClaw` tag to Zylos product card on the homepage
- Update `llms.txt` and `ai-plugin.json` with OpenClaw compatibility mention

Reflects Howard's zylos-core README update (Capability Mapping table). Per Kevin's directive to align COCO public-facing materials.

## Files changed
- `i18n/en.yaml` / `i18n/zh-cn.yaml` — Zylos descriptions
- `content/zylos-core/_index.md` / `_index.zh-cn.md` — New compatibility section
- `content/_index.md` — Zylos listing description
- `layouts/partials/home/custom.html` — OpenClaw tag on product card
- `static/llms.txt` — Zylos Core description
- `static/.well-known/ai-plugin.json` — Model-facing description

## Test plan
- [ ] Verify Hugo builds without errors
- [ ] Check EN and ZH-CN pages render correctly
- [ ] Confirm OpenClaw mentions appear naturally in context

🤖 Generated with [Claude Code](https://claude.com/claude-code)