### PR TITLE
chore: align Zylos content with OpenClaw ecosystem positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Open-source tools and infrastructure for human-agent collaboration.
 
 ## Products
 
-### Zylos Series — Open Source Agent Framework
+### Zylos Series — OpenClaw-Compatible Agent Framework
 
 | Product | Description | Links |
 |---------|-------------|-------|
-| **Zylos** | Autonomous AI agent framework — persistent memory, multi-channel communication, task scheduling, extensible skills | [Repo](https://github.com/zylos-ai/zylos-core) |
+| **Zylos** | Enterprise AI agent framework (OpenClaw compatible) — persistent memory, multi-channel communication, task scheduling, extensible skills | [Repo](https://github.com/zylos-ai/zylos-core) |
 | **Zylos Telegram** | Telegram messaging component — DM, groups, media, access control | [Repo](https://github.com/zylos-ai/zylos-telegram) |
 | **Zylos Lark** | Lark & Feishu messaging component — chat, documents, calendars | [Repo](https://github.com/zylos-ai/zylos-lark) |
 | **Zylos Browser** | Browser automation component — navigate, screenshot, interact | [Repo](https://github.com/zylos-ai/zylos-browser) |

--- a/content/_index.md
+++ b/content/_index.md
@@ -7,11 +7,11 @@ description: "Products and tools by COCO"
 Building tools that empower humans and AI agents to work together seamlessly.
 {{< /lead >}}
 
-## Zylos Series — Open Source Framework
+## Zylos Series — OpenClaw-Compatible Framework
 
 | Product | Description | |
 |---------|-------------|---|
-| **[Zylos](zylos-core/)** | Autonomous AI agent framework | {{< button href="https://github.com/zylos-ai/zylos-core" target="_blank" >}}GitHub{{< /button >}} |
+| **[Zylos](zylos-core/)** | Enterprise AI agent framework (OpenClaw compatible) | {{< button href="https://github.com/zylos-ai/zylos-core" target="_blank" >}}GitHub{{< /button >}} |
 | **Zylos Telegram** | Telegram messaging component | {{< button href="https://github.com/zylos-ai/zylos-telegram" target="_blank" >}}GitHub{{< /button >}} |
 
 {{< button href="https://github.com/zylos-ai" target="_blank" >}}More Zylos Projects →{{< /button >}}

--- a/content/zylos-core/_index.md
+++ b/content/zylos-core/_index.md
@@ -1,15 +1,15 @@
 ---
 title: "Zylos"
-description: "Autonomous AI agent framework"
+description: "Enterprise AI agent framework — OpenClaw compatible"
 weight: 7
 layout: "product"
 ---
 
 <div class="product-hero">
-  <span class="badge">Agent Framework</span>
+  <span class="badge">OpenClaw-Compatible Agent Framework</span>
   <h1>Zylos</h1>
   <p class="tagline">
-    Open-source framework for building autonomous AI agents. Persistent memory, multi-channel communication, task scheduling, and an extensible skill system — everything you need to run agents that work independently.
+    Open-source framework for building autonomous AI agents. Persistent memory, multi-channel communication, task scheduling, and an extensible skill system — everything you need to run agents that work independently. Fully compatible with the OpenClaw ecosystem.
   </p>
   <div class="hero-actions">
     <a href="https://github.com/zylos-ai/zylos-core" target="_blank" class="btn-primary">View on GitHub &rarr;</a>

--- a/content/zylos-core/_index.zh-cn.md
+++ b/content/zylos-core/_index.zh-cn.md
@@ -1,15 +1,15 @@
 ---
 title: "Zylos"
-description: "自主 AI Agent 框架"
+description: "企业级 AI Agent 框架 — 兼容 OpenClaw"
 weight: 7
 layout: "product"
 ---
 
 <div class="product-hero">
-  <span class="badge">Agent 框架</span>
+  <span class="badge">兼容 OpenClaw 的 Agent 框架</span>
   <h1>Zylos</h1>
   <p class="tagline">
-    开源自主 AI Agent 框架。持久记忆、多通道通信、任务调度和可扩展技能系统——构建独立运行的 Agent 所需的一切。
+    开源自主 AI Agent 框架。持久记忆、多通道通信、任务调度和可扩展技能系统——构建独立运行的 Agent 所需的一切。完全兼容 OpenClaw 生态。
   </p>
   <div class="hero-actions">
     <a href="https://github.com/zylos-ai/zylos-core" target="_blank" class="btn-primary">在 GitHub 查看 &rarr;</a>

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -7,7 +7,7 @@ home:
   section_featured: "Featured Projects"
   section_claw: "Claw Series — User-Facing Tools"
   section_hxa: "HxA Infrastructure — Agent Collaboration"
-  section_zylos: "Zylos Series — Open Source Framework"
+  section_zylos: "Zylos Series — OpenClaw-Compatible Agent Framework"
   section_coming_soon: "Coming Soon"
 
 status:
@@ -42,8 +42,8 @@ products:
   hxa_workspace_desc: "Collaboration platform with identity management, shared knowledge, dashboards, and multi-agent meetings."
 
   zylos_core_name: "Zylos"
-  zylos_core_desc: "Autonomous AI agent framework. Persistent memory, multi-channel communication, task scheduling, and extensible skill system."
-  zylos_core_featured_desc: "Give your AI a life — open-source agent infrastructure for team collaboration. Persistent memory, multi-channel communication, task scheduling, and extensible skill system."
+  zylos_core_desc: "Enterprise AI agent framework built on the OpenClaw ecosystem. Persistent memory, multi-channel communication, task scheduling, and extensible skill system."
+  zylos_core_featured_desc: "Give your AI a life — enterprise agent infrastructure built on OpenClaw. Persistent memory, multi-channel communication, task scheduling, and extensible skill system. Fully compatible with the OpenClaw ecosystem."
   zylos_telegram_name: "Zylos Telegram"
   zylos_telegram_desc: "Telegram messaging component. DM, groups, media sharing, and access control."
   zylos_lark_name: "Zylos Lark"

--- a/i18n/zh-cn.yaml
+++ b/i18n/zh-cn.yaml
@@ -7,7 +7,7 @@ home:
   section_featured: "焦点项目"
   section_claw: "Claw 系列 — 用户工具"
   section_hxa: "HxA 基础设施 — Agent 协作"
-  section_zylos: "Zylos 系列 — 开源框架"
+  section_zylos: "Zylos 系列 — 兼容 OpenClaw 的 Agent 框架"
   section_coming_soon: "即将推出"
 
 status:
@@ -42,8 +42,8 @@ products:
   hxa_workspace_desc: "协作平台——身份管理、共享知识库、仪表盘和多 Agent 会议。"
 
   zylos_core_name: "Zylos"
-  zylos_core_desc: "自主 AI Agent 框架。持久记忆、多通道通信、任务调度和可扩展技能系统。"
-  zylos_core_featured_desc: "赋予 AI 生命 — 开源 Agent 协作基础设施。持久记忆、多通道通信、任务调度和可扩展技能系统。"
+  zylos_core_desc: "基于 OpenClaw 生态的企业级 AI Agent 框架。持久记忆、多通道通信、任务调度和可扩展技能系统。"
+  zylos_core_featured_desc: "赋予 AI 生命 — 基于 OpenClaw 生态的企业级 Agent 基础设施。持久记忆、多通道通信、任务调度和可扩展技能系统。完全兼容 OpenClaw 生态。"
   zylos_telegram_name: "Zylos Telegram"
   zylos_telegram_desc: "Telegram 消息组件。私聊、群组、媒体分享和访问控制。"
   zylos_lark_name: "Zylos Lark"

--- a/static/.well-known/ai-plugin.json
+++ b/static/.well-known/ai-plugin.json
@@ -3,7 +3,7 @@
   "name_for_human": "COCO Labs",
   "name_for_model": "coco_labs",
   "description_for_human": "Open-source tools and infrastructure for human-agent collaboration.",
-  "description_for_model": "COCO Labs is a product showcase for open-source AI agent tools. Products include: Zylos (autonomous agent framework with persistent memory, multi-channel communication, task scheduling), ClawMark (web annotation Chrome extension), ClawFeed (AI RSS reader), HxA Connect (agent-to-agent messaging protocol), and HxA Teams (team organization templates). All products are free and open-source on GitHub (github.com/coco-xyz and github.com/zylos-ai).",
+  "description_for_model": "COCO Labs is a product showcase for open-source AI agent tools. Products include: Zylos (OpenClaw-compatible autonomous agent framework with persistent memory, multi-channel communication, task scheduling), ClawMark (web annotation Chrome extension), ClawFeed (AI RSS reader), HxA Connect (agent-to-agent messaging protocol), and HxA Teams (team organization templates). All products are free and open-source on GitHub (github.com/coco-xyz and github.com/zylos-ai).",
   "auth": {
     "type": "none"
   },

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -6,8 +6,8 @@ COCO Labs is the product showcase for COCO (coco.xyz), an organization building 
 
 ## Products
 
-### Zylos Series — Open Source Agent Framework
-- [Zylos Core](https://labs.coco.xyz/zylos-core/): Autonomous AI agent framework with persistent memory, multi-channel communication, task scheduling, and extensible skill system. GitHub: https://github.com/zylos-ai/zylos-core
+### Zylos Series — OpenClaw-Compatible Agent Framework
+- [Zylos Core](https://labs.coco.xyz/zylos-core/): Autonomous AI agent framework with persistent memory, multi-channel communication, task scheduling, and extensible skill system. Fully compatible with the OpenClaw ecosystem. GitHub: https://github.com/zylos-ai/zylos-core
 - Zylos Telegram: Telegram messaging component. GitHub: https://github.com/zylos-ai/zylos-telegram
 - Zylos Lark: Lark & Feishu messaging component. GitHub: https://github.com/zylos-ai/zylos-lark
 - Zylos Browser: Browser automation component. GitHub: https://github.com/zylos-ai/zylos-browser


### PR DESCRIPTION
## Summary

Updates all Zylos-related content across the coco-labs site to emphasize OpenClaw compatibility, per Kevin's directive on ecosystem positioning.

### Files changed (8):

- **i18n/en.yaml** — Section title, `zylos_core_desc`, and `zylos_core_featured_desc` updated with OpenClaw references
- **i18n/zh-cn.yaml** — Chinese equivalents of the above
- **content/zylos-core/_index.md** — Description, badge, and tagline updated
- **content/zylos-core/_index.zh-cn.md** — Chinese equivalents of the above
- **content/_index.md** — Section heading and product table description
- **static/llms.txt** — Section heading and Zylos Core description for LLM consumption
- **static/.well-known/ai-plugin.json** — Added "OpenClaw-compatible" to model description
- **README.md** — Section heading and Zylos table row description

### Context

Audit source: `~/zylos/workspace/zylos-oc-audit.md`. Kevin directive to align Zylos positioning with the OpenClaw ecosystem.

## Test plan

- [ ] Verify Hugo builds without errors (`hugo server`)
- [ ] Check English and Chinese pages render correctly
- [ ] Confirm llms.txt and ai-plugin.json are well-formed

🤖 Generated with [Claude Code](https://claude.com/claude-code)