### PR TITLE
fix: restore Labs header text

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -53,7 +53,7 @@ languages:
           weight: 40
 
 params:
-  disableTextInHeader: true
+  headerTitle: "Labs"
   highlightCurrentMenuArea: true
   logo: "images/logo/horizontal-black.svg"
   secondaryLogo: "images/logo/horizontal-brand-yellow.svg"


### PR DESCRIPTION
## Summary
- Restores `headerTitle: "Labs"` in hugo.yaml (was removed by PR #59)
- Logo SVG updates from #59 are kept — only the header text is reverted
- Per Charlie's direction: keep "Labs" text in header

Closes #60 (superseded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)