### PR TITLE
Add Zylos Recruit to Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Open-source tools and infrastructure for human-agent collaboration.
 |---------|-------------|-------|
 | **Zylos** | Autonomous AI agent framework — persistent memory, multi-channel communication, task scheduling, extensible skills | [Repo](https://github.com/zylos-ai/zylos-core) |
 | **Zylos Telegram** | Telegram messaging component — DM, groups, media, access control | [Repo](https://github.com/zylos-ai/zylos-telegram) |
+| **Zylos Recruit** | AI-assisted recruiting ATS — resume evaluation, role matching, role portrait discovery, reference interview questions, candidate pipeline | [Page](https://labs.coco.xyz/zylos-recruit/) · [Repo](https://github.com/zz-howard/zylos-recruit) |
 | **Zylos Lark** | Lark & Feishu messaging component — chat, documents, calendars | [Repo](https://github.com/zylos-ai/zylos-lark) |
 | **Zylos Browser** | Browser automation component — navigate, screenshot, interact | [Repo](https://github.com/zylos-ai/zylos-browser) |
 | **Zylos ImageGen** | AI image generation using Google Gemini | [Repo](https://github.com/zylos-ai/zylos-imagegen) |

--- a/content/_index.md
+++ b/content/_index.md
@@ -13,6 +13,7 @@ Building tools that empower humans and AI agents to work together seamlessly.
 |---------|-------------|---|
 | **[Zylos](zylos-core/)** | Autonomous AI agent framework | {{< button href="https://github.com/zylos-ai/zylos-core" target="_blank" >}}GitHub{{< /button >}} |
 | **Zylos Telegram** | Telegram messaging component | {{< button href="https://github.com/zylos-ai/zylos-telegram" target="_blank" >}}GitHub{{< /button >}} |
+| **[Zylos Recruit](zylos-recruit/)** | AI-assisted recruiting ATS | {{< button href="https://github.com/zz-howard/zylos-recruit" target="_blank" >}}GitHub{{< /button >}} |
 
 {{< button href="https://github.com/zylos-ai" target="_blank" >}}More Zylos Projects →{{< /button >}}
 

--- a/content/zylos-recruit/_index.md
+++ b/content/zylos-recruit/_index.md
@@ -72,7 +72,7 @@ layout: "product"
   <h2>Install</h2>
 
 ```bash
-zylos add recruit
+zylos add zz-howard/zylos-recruit
 ```
 
 </div>

--- a/content/zylos-recruit/_index.md
+++ b/content/zylos-recruit/_index.md
@@ -1,0 +1,83 @@
+---
+title: "Zylos Recruit"
+description: "AI-assisted recruiting ATS"
+weight: 8
+layout: "product"
+---
+
+<div class="product-hero">
+  <span class="badge">Recruiting ATS</span>
+  <h1>Zylos Recruit</h1>
+  <p class="tagline">
+    Lightweight AI-assisted ATS for resume evaluation, role matching, role portrait discovery, reference interview-question generation, and candidate pipeline management.
+  </p>
+  <div class="hero-actions">
+    <a href="https://github.com/zz-howard/zylos-recruit" target="_blank" class="btn-primary">View on GitHub &rarr;</a>
+  </div>
+</div>
+
+<div class="features-section">
+  <h2>Key Features</h2>
+  <div class="features-grid">
+    <div class="feature-card">
+      <div class="feature-icon">&#128196;</div>
+      <h3>AI Resume Evaluation</h3>
+      <p>Upload PDF resumes and evaluate candidates against a role JD and expected candidate portrait with structured recommendations, match scores, strengths, risks, and interview focus.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128203;</div>
+      <h3>Candidate Pipeline</h3>
+      <p>Manage candidates through a compact ATS workflow: pending, scheduled, interviewed, passed, and talent pool.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128100;</div>
+      <h3>Role Portraits</h3>
+      <p>Run internal stakeholder conversations to clarify hiring needs, generate one or more role portraits, and save them into the role library.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128221;</div>
+      <h3>Interview References</h3>
+      <p>Generate Pages-backed reference interview-question documents grounded in the candidate resume, role context, and prior evaluation for human interviewers.</p>
+    </div>
+  </div>
+</div>
+
+<div class="features-section">
+  <h2>Reference Application Patterns</h2>
+  <div class="features-grid">
+    <div class="feature-card">
+      <div class="feature-icon">&#9889;</div>
+      <h3>Local AI Runtime Reuse</h3>
+      <p>Uses configurable local AI runtimes such as Claude, Codex, Gemini, or ChatGPT instead of hard-coding a single API provider.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128274;</div>
+      <h3>Sandboxed Data Access</h3>
+      <p>Runs CLI-based AI calls through bubblewrap when available, exposing only the scoped files needed for each task.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128257;</div>
+      <h3>Session Context</h3>
+      <p>Maintains multi-turn context for internal role-discovery conversations while keeping company, candidate, resume, and role data scoped.</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128279;</div>
+      <h3>Agent-Friendly API</h3>
+      <p>REST APIs and Bearer token authentication make it practical for agents, scripts, and external workflows to submit and manage candidates.</p>
+    </div>
+  </div>
+</div>
+
+<div class="quickstart-section">
+  <h2>Install</h2>
+
+```bash
+zylos add recruit
+```
+
+</div>
+
+<div class="bottom-links">
+  <a href="https://github.com/zz-howard/zylos-recruit" target="_blank">GitHub &nearr;</a>
+  <a href="https://github.com/zylos-ai" target="_blank">Zylos Org &nearr;</a>
+</div>

--- a/content/zylos-recruit/_index.zh-cn.md
+++ b/content/zylos-recruit/_index.zh-cn.md
@@ -1,0 +1,83 @@
+---
+title: "Zylos Recruit"
+description: "AI 辅助招聘 ATS"
+weight: 8
+layout: "product"
+---
+
+<div class="product-hero">
+  <span class="badge">招聘 ATS</span>
+  <h1>Zylos Recruit</h1>
+  <p class="tagline">
+    轻量级 AI 辅助招聘 ATS，用于简历评估、岗位匹配、岗位画像访谈、参考面试题生成和候选人流程管理。
+  </p>
+  <div class="hero-actions">
+    <a href="https://github.com/zz-howard/zylos-recruit" target="_blank" class="btn-primary">在 GitHub 查看 &rarr;</a>
+  </div>
+</div>
+
+<div class="features-section">
+  <h2>核心功能</h2>
+  <div class="features-grid">
+    <div class="feature-card">
+      <div class="feature-icon">&#128196;</div>
+      <h3>AI 简历评估</h3>
+      <p>上传 PDF 简历，基于岗位 JD 和期望候选人画像做结构化评估，输出推荐结论、匹配分数、亮点、风险和面试关注点。</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128203;</div>
+      <h3>候选人流程管理</h3>
+      <p>通过紧凑的 ATS 流程管理候选人状态：待处理、已约面、已面试、通过和人才库。</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128100;</div>
+      <h3>岗位画像</h3>
+      <p>通过内部岗位需求访谈澄清招聘目标，生成一个或多个岗位画像草稿，并沉淀到岗位资料库。</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128221;</div>
+      <h3>参考面试题</h3>
+      <p>基于候选人简历、岗位上下文和已有评估生成 Pages 文档，供真人面试官作为面试参考。</p>
+    </div>
+  </div>
+</div>
+
+<div class="features-section">
+  <h2>参考应用模式</h2>
+  <div class="features-grid">
+    <div class="feature-card">
+      <div class="feature-icon">&#9889;</div>
+      <h3>复用本地 AI Runtime</h3>
+      <p>支持 Claude、Codex、Gemini、ChatGPT 等可配置本地 AI runtime，不把能力写死到单一 API Provider。</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128274;</div>
+      <h3>沙箱化数据访问</h3>
+      <p>可通过 bubblewrap 包裹 CLI 型 AI 调用，让每次任务只看到必要的受控文件范围。</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128257;</div>
+      <h3>Session 上下文</h3>
+      <p>为内部岗位画像访谈维护多轮上下文，同时保持公司、候选人、简历和岗位数据的边界。</p>
+    </div>
+    <div class="feature-card">
+      <div class="feature-icon">&#128279;</div>
+      <h3>Agent 友好 API</h3>
+      <p>REST API 和 Bearer Token 认证方便 Agent、脚本和外部工作流提交和管理候选人。</p>
+    </div>
+  </div>
+</div>
+
+<div class="quickstart-section">
+  <h2>安装</h2>
+
+```bash
+zylos add recruit
+```
+
+</div>
+
+<div class="bottom-links">
+  <a href="https://github.com/zz-howard/zylos-recruit" target="_blank">GitHub &nearr;</a>
+  <a href="https://github.com/zylos-ai" target="_blank">Zylos Org &nearr;</a>
+</div>

--- a/content/zylos-recruit/_index.zh-cn.md
+++ b/content/zylos-recruit/_index.zh-cn.md
@@ -72,7 +72,7 @@ layout: "product"
   <h2>安装</h2>
 
 ```bash
-zylos add recruit
+zylos add zz-howard/zylos-recruit
 ```
 
 </div>

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -46,6 +46,8 @@ products:
   zylos_core_featured_desc: "Give your AI a life — open-source agent infrastructure for team collaboration. Persistent memory, multi-channel communication, task scheduling, and extensible skill system."
   zylos_telegram_name: "Zylos Telegram"
   zylos_telegram_desc: "Telegram messaging component. DM, groups, media sharing, and access control."
+  zylos_recruit_name: "Zylos Recruit"
+  zylos_recruit_desc: "AI-assisted recruiting ATS for resume evaluation, role matching, role portrait discovery, reference interview questions, and candidate pipeline management."
   zylos_lark_name: "Zylos Lark"
   zylos_lark_desc: "Lark & Feishu messaging component. Chat, documents, calendars, and rich cards."
   zylos_browser_name: "Zylos Browser"

--- a/i18n/zh-cn.yaml
+++ b/i18n/zh-cn.yaml
@@ -46,6 +46,8 @@ products:
   zylos_core_featured_desc: "赋予 AI 生命 — 开源 Agent 协作基础设施。持久记忆、多通道通信、任务调度和可扩展技能系统。"
   zylos_telegram_name: "Zylos Telegram"
   zylos_telegram_desc: "Telegram 消息组件。私聊、群组、媒体分享和访问控制。"
+  zylos_recruit_name: "Zylos Recruit"
+  zylos_recruit_desc: "AI 辅助招聘 ATS，用于简历评估、岗位匹配、岗位画像访谈、参考面试题和候选人流程管理。"
   zylos_lark_name: "Zylos Lark"
   zylos_lark_desc: "飞书/Lark 消息组件。聊天、文档、日历和富文本卡片。"
   zylos_browser_name: "Zylos Browser"

--- a/layouts/partials/home/custom.html
+++ b/layouts/partials/home/custom.html
@@ -115,6 +115,20 @@
       </div>
     </a>
 
+    <a href="{{ "zylos-recruit/" | relURL }}" class="product-card">
+      <div class="product-card-header">
+        <span class="status-badge status-beta">{{ i18n "status.beta" }}</span>
+      </div>
+      <div class="card-icon">&#128188;</div>
+      <h3>{{ i18n "products.zylos_recruit_name" }}</h3>
+      <p>{{ i18n "products.zylos_recruit_desc" }}</p>
+      <div class="card-tags">
+        <span class="card-tag">#recruiting</span>
+        <span class="card-tag">#ATS</span>
+        <span class="card-tag">#agent</span>
+      </div>
+    </a>
+
   </div>
   <div style="text-align:center; margin-top: 0.5rem; margin-bottom: 2rem;">
     <a href="https://github.com/zylos-ai" target="_blank" class="more-link">{{ i18n "common.more_zylos" }} &rarr;</a>

--- a/static/.well-known/ai-plugin.json
+++ b/static/.well-known/ai-plugin.json
@@ -3,7 +3,7 @@
   "name_for_human": "COCO Labs",
   "name_for_model": "coco_labs",
   "description_for_human": "Open-source tools and infrastructure for human-agent collaboration.",
-  "description_for_model": "COCO Labs is a product showcase for open-source AI agent tools. Products include: Zylos (autonomous agent framework with persistent memory, multi-channel communication, task scheduling), ClawMark (web annotation Chrome extension), ClawFeed (AI RSS reader), HxA Connect (agent-to-agent messaging protocol), and HxA Teams (team organization templates). All products are free and open-source on GitHub (github.com/coco-xyz and github.com/zylos-ai).",
+  "description_for_model": "COCO Labs is a product showcase for open-source AI agent tools. Products include: Zylos (autonomous agent framework with persistent memory, multi-channel communication, task scheduling), Zylos Recruit (AI-assisted recruiting ATS for resume evaluation, role matching, role portrait discovery, and candidate pipeline management), ClawMark (web annotation Chrome extension), ClawFeed (AI RSS reader), HxA Connect (agent-to-agent messaging protocol), and HxA Teams (team organization templates). All products are free and open-source on GitHub (github.com/coco-xyz, github.com/zylos-ai, and github.com/zz-howard).",
   "auth": {
     "type": "none"
   },

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -9,6 +9,7 @@ COCO Labs is the product showcase for COCO (coco.xyz), an organization building 
 ### Zylos Series — Open Source Agent Framework
 - [Zylos Core](https://labs.coco.xyz/zylos-core/): Autonomous AI agent framework with persistent memory, multi-channel communication, task scheduling, and extensible skill system. GitHub: https://github.com/zylos-ai/zylos-core
 - Zylos Telegram: Telegram messaging component. GitHub: https://github.com/zylos-ai/zylos-telegram
+- [Zylos Recruit](https://labs.coco.xyz/zylos-recruit/): AI-assisted recruiting ATS for resume evaluation, role matching, role portrait discovery, reference interview-question generation, and candidate pipeline management. GitHub: https://github.com/zz-howard/zylos-recruit
 - Zylos Lark: Lark & Feishu messaging component. GitHub: https://github.com/zylos-ai/zylos-lark
 - Zylos Browser: Browser automation component. GitHub: https://github.com/zylos-ai/zylos-browser
 - Zylos ImageGen: AI image generation using Google Gemini. GitHub: https://github.com/zylos-ai/zylos-imagegen


### PR DESCRIPTION
## Summary
- add English and Chinese product pages for Zylos Recruit
- add Zylos Recruit to the homepage Zylos Series cards
- update i18n copy, README, llms.txt, and ai-plugin metadata

## Verification
- docker run --rm --user "1000:1000" -v "/home/howard/zylos/workspace/coco-labs:/src" -w /src ghcr.io/gohugoio/hugo:v0.151.0 --minify