### PR TITLE
ci: add SAST (Semgrep + Gitleaks)

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -1,0 +1,33 @@
+name: SAST
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: Semgrep Code Scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Semgrep
+        run: semgrep scan --config auto --error --severity ERROR
+
+  gitleaks:
+    name: Gitleaks Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Gitleaks
+        run: |
+          GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | cut -d'"' -f4 | sed 's/^v//')
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz -C /usr/local/bin gitleaks
+      - name: Run Gitleaks
+        run: gitleaks detect --source . --verbose


### PR DESCRIPTION
## Summary
- Add Semgrep SAST scanning for security vulnerabilities
- Add Gitleaks secret detection to prevent credential leaks
- SOC 2 compliance requirement (SA-1-6)

## Test plan
- [ ] Semgrep scan passes on this PR
- [ ] Gitleaks scan passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)